### PR TITLE
chore(repo): add renovate to the repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc -p .",
     "clean": "rm -rf dist",
     "prettier": "npm run prettier.base -- --write",
-    "prettier.base": "prettier --cache \"./src/**/*.ts\"",
+    "prettier.base": "prettier --cache \"./src/**/*.ts\" \"renovate.json5\"",
     "prettier.dry-run": "npm run prettier.base -- --list-different",
     "test": "vitest",
     "test.coverage": "vitest --coverage"

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,61 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  /**
+   * Documentation: https://docs.renovatebot.com/configuration-options
+   *
+   * This configuration file can be locally validated:
+   * 1. `npm i -g renovate` will install the validator
+   * 2. `renovate-config-validator` will run the validator
+   */
+  dependencyDashboard: true,
+  /**
+   * Apply these labels to every PR
+   */
+  labels: ['dependencies'],
+  /**
+   * The minimum age (in days) for updates that have a release timestamp header to be PR'ed.
+   * This will not batch releases together - if package A gets a release on Monday, Tuesday and Wednesday and has a
+   * `minimumReleaseAge: 3` and runs every day, then a PR will be created on:
+   * - Thursday (for Monday's release)
+   * - Friday (for Tuesday's release)
+   * - Saturday (for Wednesday's release)
+   *
+   * This setting is to prevent a compromised package from being merged into Stencil in the first three days of its
+   * release date
+   *
+   * A value of 3 days was chosen as npm packages younger than 72 hours old can be unpublished. This prevents merging
+   * support for a package that could be removed from the registry.
+   */
+  minimumReleaseAge: '3 days',
+  /**
+   * Note: Renovate will evaluate all packageRules and not stop once it gets a first match.
+   */
+  packageRules: [
+    {
+      matchPackageNames: ['@types/node'],
+      allowedVersions: '<21.0.0',
+    },
+  ],
+  // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
+  rebaseWhen: 'never',
+  /**
+   * Run every Monday and Thursday between midnight at 11 AM (in UTC)
+   *
+   * Monday and Thursday were chosen to:
+   * - Keep the `minimumReleaseAge` value in mind (three days)
+   * - Prevent spikes/bursts of PRs from Renovate on a single day of the week
+   *
+   * We use cron syntax here as it's more deterministic/easier to provide a value that we know that Renovate will
+   * accept, compared to the natural language syntax which is (subjectively) trickier to test without merging first.
+   *
+   * {@see https://crontab.guru} for debugging cron schedules
+   */
+  schedule: ['* 0-11 * * 1,4'],
+  /**
+   * Ensure semantic commits are enabled for commits + PR titles.
+   *
+   * By default, Angular-style semantic commits will have a type of 'chore' and a scope of 'deps':
+   * `chore(deps): _your git commit title here_`
+   */
+  semanticCommits: 'enabled',
+}


### PR DESCRIPTION
keep dependencies up to date with renovate. this is a naive configuration file, since we can't _really_ test this thing to verify that it exists exactly how we want it to without landing it. consider this a 'first pass' of sorts with known-good defaults that we've been using in StencilJS