### PR TITLE
feat(html): implement go to declaration for custom elms

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -10,8 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@stencil-community/web-types-output-target": "file:..",
-        "@stencil/core": "^4.7.0",
-        "@types/node": "^20.0.0"
+        "@stencil/core": "^4.7.0"
       }
     },
     "..": {
@@ -22,7 +21,8 @@
       "devDependencies": {
         "@ionic/prettier-config": "^4.0.0",
         "@release-it/conventional-changelog": "^8.0.1",
-        "@stencil/core": "^4.17.1",
+        "@stencil/core": "^4.13.0",
+        "@types/node": "^20.12.8",
         "@vitest/coverage-v8": "^1.5.0",
         "prettier": "3.2.5",
         "release-it": "^17.2.0",
@@ -46,21 +46,6 @@
         "node": ">=16.0.0",
         "npm": ">=7.10.0"
       }
-    },
-    "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
-      "dev": true,
-      "dependencies": {
-        "undici-types": "~5.26.4"
-      }
-    },
-    "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
     }
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -40,8 +40,7 @@
   },
   "devDependencies": {
     "@stencil-community/web-types-output-target": "file:..",
-    "@stencil/core": "^4.7.0",
-    "@types/node": "^20.0.0"
+    "@stencil/core": "^4.7.0"
   },
   "license": "MIT",
   "web-types": "./web-types.json"

--- a/example/src/index.html
+++ b/example/src/index.html
@@ -1,4 +1,6 @@
 <!DOCTYPE html>
+<!-- For any of the components in this file, right-clicking on the tag name->"Go To"->"Declaration or Usages" will -->
+<!-- take you to the component's class definition file. -->
 <html dir="ltr" lang="en">
   <head>
     <meta charset="utf-8" />
@@ -23,6 +25,7 @@
   </head>
   <body>
     <!-- See the repo's README for setup instructions -->
+
     <!-- After setup, hover over the component name and each of the props -->
     <!--
          - my-component will have its description pulled from it's JSDoc

--- a/example/web-types.json
+++ b/example/web-types.json
@@ -10,6 +10,10 @@
           "name": "my-component",
           "deprecated": false,
           "description": "A component for displaying a person's name",
+          "source": {
+            "module": "src/components/my-component/my-component.tsx",
+            "symbol": "MyComponent"
+          },
           "attributes": [
             {
               "name": "first",
@@ -45,14 +49,16 @@
             }
           ],
           "slots": [],
-          "css": {
-            "parts": []
-          }
+          "css": {}
         },
         {
           "name": "shadow-parts",
           "deprecated": false,
           "description": "An example using Shadow Parts.\n\nThe 'label' part is declared in the component-level JSDoc using \"@part NAME - DESCRIPTION\".",
+          "source": {
+            "module": "src/components/shadow-parts/shadow-parts.tsx",
+            "symbol": "ShadowParts"
+          },
           "attributes": [],
           "slots": [],
           "css": {
@@ -72,6 +78,10 @@
           "name": "slot-example",
           "deprecated": false,
           "description": "",
+          "source": {
+            "module": "src/components/slot-example/slot-example.tsx",
+            "symbol": "SlotExample"
+          },
           "attributes": [],
           "slots": [
             {
@@ -87,9 +97,7 @@
               "description": ""
             }
           ],
-          "css": {
-            "parts": []
-          }
+          "css": {}
         }
       ]
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@ionic/prettier-config": "^4.0.0",
         "@release-it/conventional-changelog": "^8.0.1",
         "@stencil/core": "^4.13.0",
+        "@types/node": "^20.12.8",
         "@vitest/coverage-v8": "^1.5.0",
         "prettier": "3.2.5",
         "release-it": "^17.2.0",
@@ -1204,6 +1205,15 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
       "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.12.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
+      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -6899,6 +6909,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unicorn-magic": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ionic/prettier-config": "^4.0.0",
     "@release-it/conventional-changelog": "^8.0.1",
     "@stencil/core": "^4.13.0",
+    "@types/node": "^20.12.8",
     "@vitest/coverage-v8": "^1.5.0",
     "prettier": "3.2.5",
     "release-it": "^17.2.0",

--- a/src/contributions/html-contributions.test.ts
+++ b/src/contributions/html-contributions.test.ts
@@ -3,10 +3,13 @@ import { generateElementInfo } from './html-contributions';
 import { ElementInfo } from '../index';
 import { ComponentCompilerMeta } from '@stencil/core/internal';
 
-// TODO(NOW): Additional testing
+const MOCK_STENCIL_ROOT_DIR = '/';
+const MOCK_CLASS_COMPONENT_NAME = 'StubCmp';
+const MOCK_MODULE_PATH = 'some/stubbed/path/my-component.tsx';
+
 describe('generateElementInfo', () => {
   it('returns an empty array when no components are provided', () => {
-    expect([]).toEqual(generateElementInfo([]));
+    expect([]).toEqual(generateElementInfo([], MOCK_STENCIL_ROOT_DIR));
   });
 
   it.each(['deprecated', 'DEPRECATED', 'Deprecated'])('marks a component as deprecated', (deprecated: string) => {
@@ -23,12 +26,13 @@ describe('generateElementInfo', () => {
       name: 'my-component',
       deprecated: true,
       description: 'a simple component that shows us your name',
+      source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
       attributes: [],
       slots: [],
       css: {},
     };
 
-    const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+    const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
     expect(actual).toHaveLength(1);
     expect(actual[0]).toEqual(expected);
@@ -53,13 +57,14 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [],
         css: {},
       };
 
       cmpMeta.properties = [];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -97,7 +102,7 @@ describe('generateElementInfo', () => {
         },
       ];
 
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0].attributes).toHaveLength(0);
@@ -108,6 +113,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [
           {
             default: 'Bob',
@@ -139,17 +145,18 @@ describe('generateElementInfo', () => {
           complexType: { original: 'string', resolved: 'string', references: {} },
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
     });
 
-    it.each(['deprecated', 'DEPRECATED', 'Deprecated'])('marks an attribute as deprecated', (deprecated) => {
+    it.each(['deprecated', 'DEPRECATED', 'Deprecated'])("'%s' marks an attribute as deprecated", (deprecated) => {
       const expected: ElementInfo = {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [
           {
             default: 'Bob',
@@ -181,7 +188,7 @@ describe('generateElementInfo', () => {
           complexType: { original: 'string', resolved: 'string', references: {} },
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -207,6 +214,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: true,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [],
         css: {},
@@ -218,7 +226,7 @@ describe('generateElementInfo', () => {
           text: "please don't use this",
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -229,6 +237,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [
           {
@@ -245,7 +254,7 @@ describe('generateElementInfo', () => {
           text: '- Content is placed between the named slots if provided without a slot.',
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -256,6 +265,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [
           {
@@ -272,7 +282,7 @@ describe('generateElementInfo', () => {
           text: 'primary ',
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -283,6 +293,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [
           {
@@ -299,7 +310,7 @@ describe('generateElementInfo', () => {
           text: 'secondary - Content is placed to the right of the main slotted in text',
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -325,6 +336,7 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [],
         css: {
@@ -346,7 +358,7 @@ describe('generateElementInfo', () => {
           text: 'another-label - Another label describing the component',
         },
       ];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -357,13 +369,14 @@ describe('generateElementInfo', () => {
         name: 'my-component',
         deprecated: false,
         description: 'a simple component that shows us your name',
+        source: { module: MOCK_MODULE_PATH, symbol: MOCK_CLASS_COMPONENT_NAME },
         attributes: [],
         slots: [],
         css: {},
       };
 
       cmpMeta.docs.tags = [];
-      const actual: ElementInfo[] = generateElementInfo([cmpMeta]);
+      const actual: ElementInfo[] = generateElementInfo([cmpMeta], MOCK_STENCIL_ROOT_DIR);
 
       expect(actual).toHaveLength(1);
       expect(actual[0]).toEqual(expected);
@@ -383,7 +396,7 @@ describe('generateElementInfo', () => {
 export const stubComponentCompilerMeta = (overrides: Partial<ComponentCompilerMeta> = {}): ComponentCompilerMeta => ({
   assetsDirs: [],
   attachInternalsMemberName: null,
-  componentClassName: 'StubCmp',
+  componentClassName: MOCK_CLASS_COMPONENT_NAME,
   dependencies: [],
   dependents: [],
   directDependencies: [],
@@ -452,7 +465,7 @@ export const stubComponentCompilerMeta = (overrides: Partial<ComponentCompilerMe
   potentialCmpRefs: [],
   properties: [],
   shadowDelegatesFocus: false,
-  sourceFilePath: '/some/stubbed/path/my-component.tsx',
+  sourceFilePath: `/${MOCK_MODULE_PATH}`,
   sourceMapPath: '/some/stubbed/path/my-component.js.map',
   states: [],
   styleDocs: [],

--- a/src/contributions/html-contributions.ts
+++ b/src/contributions/html-contributions.ts
@@ -6,6 +6,7 @@ import type {
 } from '@stencil/core/internal';
 import { CssPart, ElementInfo } from '../index';
 import { JsonDocsPart } from '@stencil/core/internal/stencil-public-docs';
+import { relative } from 'path';
 
 // https://plugins.jetbrains.com/docs/intellij/websymbols-web-types.html#web-components
 // https://github.com/JetBrains/web-types/blob/2c07137416e4151bfaf44bf3226dca7f1a5e9bd3/schema/web-types.json#L303
@@ -14,8 +15,13 @@ import { JsonDocsPart } from '@stencil/core/internal/stencil-public-docs';
 /**
  * Generate an array of symbol contributions to the HTML namespace
  * @param componentMetadata the Stencil component metadata to generate info for to contribute to the HTML namespace
+ * @param stencilRootDir the root directory of a Stencil project
+ * @returns the symbol contributions to the HTML namespace
  */
-export const generateElementInfo = (componentMetadata: ComponentCompilerMeta[]): ElementInfo[] => {
+export const generateElementInfo = (
+  componentMetadata: ComponentCompilerMeta[],
+  stencilRootDir: string,
+): ElementInfo[] => {
   return componentMetadata.map((cmpMeta: ComponentCompilerMeta): ElementInfo => {
     // avoid serializing parts for css contributions for an element if we can avoid it
     let cssParts: CssPart[] | undefined = getDocsParts(cmpMeta.htmlParts, cmpMeta.docs.tags).map((parts) => {
@@ -27,6 +33,10 @@ export const generateElementInfo = (componentMetadata: ComponentCompilerMeta[]):
       name: cmpMeta.tagName,
       deprecated: !!cmpMeta.docs.tags.find((tag) => tag.name.toLowerCase() === 'deprecated'),
       description: cmpMeta.docs.text,
+      source: {
+        module: relative(stencilRootDir, cmpMeta.sourceFilePath),
+        symbol: cmpMeta.componentClassName,
+      },
       attributes: cmpMeta.properties
         .filter((prop: ComponentCompilerProperty): prop is ComponentCompilerProperty & { attribute: string } => {
           return !!prop.attribute;

--- a/src/generate-web-types.test.ts
+++ b/src/generate-web-types.test.ts
@@ -3,6 +3,8 @@ import { BuildCtx } from '@stencil/core/internal';
 import { WebType } from './index';
 import { getWebTypesInfo, generateWebTypes } from './generate-web-types';
 
+const MOCK_WORKING_DIR = '/tmp/mock/dir';
+
 describe('getWebTypesInfo', () => {
   it('returns a well formed object', () => {
     const expected = {
@@ -32,7 +34,7 @@ describe('generateWebTypes', () => {
     };
 
     const buildCtx = mockBuildCtx();
-    const actual = generateWebTypes(buildCtx);
+    const actual = generateWebTypes(buildCtx, MOCK_WORKING_DIR);
 
     expect(actual).toEqual(expected);
   });
@@ -50,7 +52,7 @@ describe('generateWebTypes', () => {
     };
 
     const buildCtx = mockBuildCtx({ packageJson: {} });
-    const actual = generateWebTypes(buildCtx);
+    const actual = generateWebTypes(buildCtx, MOCK_WORKING_DIR);
 
     expect(actual).toEqual(expected);
   });

--- a/src/generate-web-types.ts
+++ b/src/generate-web-types.ts
@@ -6,9 +6,10 @@ import { WebType } from './index';
 /**
  * Generate the contents of the web-types document
  * @param buildCtx the Stencil build context, which holds the build-time metadata for a project's Stencil components
+ * @param stencilRootDir the root directory of a Stencil project
  * @returns the generated web-types document contents
  */
-export const generateWebTypes = (buildCtx: BuildCtx): WebType => {
+export const generateWebTypes = (buildCtx: BuildCtx, stencilRootDir: string): WebType => {
   const { components, packageJson } = buildCtx;
   const webTypesInfo = getWebTypesInfo(
     packageJson.version ?? 'UNKNOWN_VERSION',
@@ -23,7 +24,7 @@ export const generateWebTypes = (buildCtx: BuildCtx): WebType => {
       html: {
         // these are symbol kind names.
         // the full list can be found here: https://plugins.jetbrains.com/docs/intellij/websymbols-web-types.html#direct-support
-        elements: generateElementInfo(components),
+        elements: generateElementInfo(components, stencilRootDir),
       },
       js: {
         events: generateJsEvents(components),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { webTypesOutputTarget } from './index.js';
+import { Config } from '@stencil/core/internal';
+
+describe('webTypesOutputTarget', () => {
+  describe('validate', () => {
+    it('does not throw when all required fields are set', () => {
+      const config: Config = {
+        rootDir: '/some/mocked/field',
+      };
+
+      expect(() => webTypesOutputTarget().validate!(config, [])).not.toThrowError();
+    });
+
+    describe('no rootDir set', () => {
+      const EXPECTED_ERR_MSG = 'Unable to determine the Stencil root directory. Exiting without generating web types.';
+
+      it('throws an error when the root dir is set to undefined', () => {
+        expect(() => webTypesOutputTarget().validate!({ rootDir: undefined }, [])).toThrowError(EXPECTED_ERR_MSG);
+      });
+
+      it('throws an error when the root dir is missing', () => {
+        expect(() => webTypesOutputTarget().validate!({}, [])).toThrowError(EXPECTED_ERR_MSG);
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
-import type { BuildCtx, CompilerCtx, OutputTargetCustom } from '@stencil/core/internal';
-import type { Config } from '@stencil/core';
-
+import type { BuildCtx, CompilerCtx, OutputTargetCustom, Config } from '@stencil/core/internal';
 import { generateWebTypes } from './generate-web-types.js';
+import { Diagnostic } from '@stencil/core/internal/stencil-public-compiler';
 
 /**
  * A Stencil output target for generating [web-types](https://github.com/JetBrains/web-types) for a Stencil project.
@@ -20,10 +19,24 @@ import { generateWebTypes } from './generate-web-types.js';
 export const webTypesOutputTarget = (): OutputTargetCustom => ({
   type: 'custom',
   name: 'web-types-output-target',
-  async generator(_config: Config, compilerCtx: CompilerCtx, buildCtx: BuildCtx) {
+  validate(config: Config, _diagnostics: Diagnostic[]) {
+    if (typeof config.rootDir === 'undefined') {
+      // defer to Stencil to create & load ths into its diagnostics, rather than us having to generate one ourselves
+      throw new Error('Unable to determine the Stencil root directory. Exiting without generating web types.');
+    }
+  },
+  async generator(config: Config, compilerCtx: CompilerCtx, buildCtx: BuildCtx) {
     const timespan = buildCtx.createTimeSpan('generate web-types started', true);
 
-    const webTypes = generateWebTypes(buildCtx);
+    /**
+     * One source of truth to rule them all - plus, this makes testing a skosh easier, as we can mock easily.
+     * This should have been validated in the `validate` fn, hence the bang operator - Stencil doesn't allow us to
+     * return a value from `validate`, which makes a type guard that gets used in `validate` unusable in any meaningful
+     * way in `generator`
+     */
+    const stencilRootDirectory = config.rootDir!;
+    const webTypes = generateWebTypes(buildCtx, stencilRootDirectory);
+
     await compilerCtx.fs.writeFile('web-types.json', JSON.stringify(webTypes, null, 2));
 
     timespan.finish('generate web-types finished');
@@ -52,6 +65,19 @@ export type ElementInfo = {
   name: string;
   deprecated: boolean;
   description: string;
+  /**
+   * Link the custom HTML element back to the Stencil component
+   */
+  source: {
+    /**
+     * The TSX file containing the definition of the component, relative to the generated web-types.json
+     */
+    module: string;
+    /**
+     * The exported symbol (i.e. the Stencil component name)
+     */
+    symbol: string;
+  };
   attributes: AttributeInfo[];
   /**
    * All slots associated with the component.


### PR DESCRIPTION
update `ElementInfo` types to store information about their backing
implementation class - both the symbol (class name) and the file that
contains said symbol. this information is pulled from stencil's
intermediate representation when the html contributions are generated.

in order to know how to resolve the file containing the class name
(symbol), the IDE needs to have a valid path to it. the path is derived
from the stencil configuration's `rootDir` field, which represents the
root of a stencil project. this value is propagated from the output
target's entrypoint in order to have a single source of truth. in the
future, we may decide to wire up the entire config object, instead of a
single field (or a new object with a subset of configuration fields),
depending on what additional config fields are needed. for now, this
ought to be "good enough", and allows us to pass a _definitely_ set
field, rather than a bag of fields with are optional/undefined.

the `validate` function has been implemented on this output target. it
verifies that the `rootDir` field is a string on the provided `config`
object. stencil _should_ be setting this field for users, and it is not
expected they set this themselves. as a result, no additional
documentation is needed at this time. should this field be unset for
some reason, `validate` will throw an error, and defer to stencil to
create a `Diagnostic` entity and handle it appropriately