### PR TITLE
chore(renovate): group vitest packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -35,6 +35,10 @@
       matchPackageNames: ['@types/node'],
       allowedVersions: '<21.0.0',
     },
+    {
+      matchPackagePrefixes: ['@vitest', 'vitest'],
+      groupName: 'Vitest',
+    }
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',

--- a/renovate.json5
+++ b/renovate.json5
@@ -38,7 +38,7 @@
     {
       matchPackagePrefixes: ['@vitest', 'vitest'],
       groupName: 'Vitest',
-    }
+    },
   ],
   // Never rebase the branch or update it unless manually requested to avoid noisy PR emails
   rebaseWhen: 'never',


### PR DESCRIPTION
update vitest and `@vitest` packages so that they get updated together. this should prevent cases where the coverage package gets upgraded in a separate pr from the main pkg