### PR TITLE
chore(repo): add windows ci for testing 

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,25 @@
+name: Windows Tests
+
+on:
+  merge_group:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  windows-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Tests
+        run: npm test -- --no-watch

--- a/src/contributions/html-contributions.test.ts
+++ b/src/contributions/html-contributions.test.ts
@@ -2,10 +2,11 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { generateElementInfo } from './html-contributions';
 import { ElementInfo } from '../index';
 import { ComponentCompilerMeta } from '@stencil/core/internal';
+import { join } from 'node:path';
 
 const MOCK_STENCIL_ROOT_DIR = '/';
 const MOCK_CLASS_COMPONENT_NAME = 'StubCmp';
-const MOCK_MODULE_PATH = 'some/stubbed/path/my-component.tsx';
+const MOCK_MODULE_PATH = join('some', 'stubbed', 'path', 'my-component.tsx');
 
 describe('generateElementInfo', () => {
   it('returns an empty array when no components are provided', () => {


### PR DESCRIPTION
add a windows-based ci workflow to run path-based unit tests on windows.
this allows us to gain a little more confidence when pushing out changes
that might affect platforms other than the one we develop on