### PR TITLE
chore(repo): add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
add a .gitattributes file so that when prettier runs on a windows machine, the correct end of file/line character is used