### PR TITLE
perf(bundle): remove unneeded  type declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "dist/index.js",
   "files": [
     "dist/",
+    "dist/index.d.ts",
+    "!dist/**/*.d.ts",
     "!dist/**/*.test.*"
   ],
   "types": "dist/index.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,7 @@
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
+    "removeComments": true,                              /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */


### PR DESCRIPTION
remove type declarations from files that are a not a part of the output target's entrypoint. this is accomplished in `package.json` by updating the files included in the bundle.

update the `tsconfig.json` to strip comments out, as that further reduces the size of the library.