### PR TITLE
feat(config): add warning for absolute outFile

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,11 @@ export const webTypesOutputTarget = (outputTargetConfig: WebTypesConfig = {}): O
     } else if (extname(outputTargetConfig.outFile) !== '.json') {
       outputTargetConfig.outFile = join(outputTargetConfig.outFile, 'web-types.json');
     }
-    if (!isAbsolute(outputTargetConfig.outFile)) {
+    if (isAbsolute(outputTargetConfig.outFile)) {
+      console.warn(
+        `webTypesOutputTarget - 'outFile' config value appears to be absolute: '${outputTargetConfig.outFile}'. Using relative files is discouraged. See https://github.com/stencil-community/stencil-web-types?tab=readme-ov-file#outfile for information on configuring this field.`,
+      );
+    } else {
       outputTargetConfig.outFile = join(config.rootDir, outputTargetConfig.outFile);
     }
   },


### PR DESCRIPTION
add a warning when an absolute `outFile` is detected in the `stencil.config.ts` file. absolute file paths are considered to be an anti-pattern for this field, as output files locations that are absolute aren't portable between different machines.