### PR TITLE
chore(package): update pkg description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stencil-community/web-types-output-target",
   "version": "1.0.0",
-  "description": "a stencil output target for generating web-types",
+  "description": "a stencil output target for generating web types",
   "main": "dist/index.js",
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@stencil-community/web-types-output-target",
   "version": "1.0.0",
-  "description": "an experimental stencil output target supporting web-types",
+  "description": "a stencil output target for generating web-types",
   "main": "dist/index.js",
   "files": [
     "dist/",


### PR DESCRIPTION
update the `package.json#description` field. this was missed in the 1.0 release, where the package is/was described as 'an experimental' output target. now that we've hit 1.0, we're fixing up that wording just a bit