### PR TITLE
chore(renovate): group release-it packages

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,10 @@
       matchPackageNames: ['@vitest{/,}**', 'vitest{/,}**'],
     },
     {
+      groupName: 'Release It',
+      matchPackageNames: ['release-it', '@release-it/*'],
+    },
+    {
       // auto-merge anything that's not a major version bump
       matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
       automerge: true,


### PR DESCRIPTION
group release-it and related packages. with the release of release-it v18, the conventional changelog plugin needs to be updated in tandem, as it has a peer dep on release-it. grouping them ought to fix the error in github where renovate cannot perform the upgrade due to failed peer deps.