### PR TITLE
chore(renovate): update release-it glob

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -41,7 +41,7 @@
     },
     {
       groupName: 'Release It',
-      matchPackageNames: ['release-it', '@release-it/*'],
+      matchPackageNames: ['release-it', '@release-it**/*'],
     },
     {
       // auto-merge anything that's not a major version bump


### PR DESCRIPTION
update the release-it glob so that `@release-it/conventional-changelog` and `release-it` are grouped together. we got PRs to update the two (https://github.com/stencil-community/stencil-web-types/pull/203 & https://github.com/stencil-community/stencil-web-types/pull/204), but they weren't grouped. 60e0cc87aeb8bef13d6e0a382a2a10e1fbdf6b8f (#154) was supposed to fix this, but apparently did not.

from the renovate docs:

> abc**/* matches abc/def but not abc, abcd, or abc/def/ghi

https://docs.renovatebot.com/string-pattern-matching/