### PR TITLE
chore(deps): update dependency @stencil/core to v4.32.0

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -21,7 +21,7 @@
       "devDependencies": {
         "@ionic/prettier-config": "^4.0.0",
         "@release-it/conventional-changelog": "^10.0.0",
-        "@stencil/core": "^4.31.0",
+        "@stencil/core": "^4.32.0",
         "@types/node": "^20.12.8",
         "@vitest/coverage-v8": "^3.0.0",
         "prettier": "3.5.3",
@@ -147,9 +147,9 @@
       "link": true
     },
     "node_modules/@stencil/core": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.31.0.tgz",
-      "integrity": "sha512-Ei9MFJ6LPD9BMFs+klkHylbVOOYhG10Jv4bvoFf3GMH15kA41rSYkEdr4DiX84ZdErQE2qtFV/2SUyWoXh0AhA==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.32.0.tgz",
+      "integrity": "sha512-2sT6UqEzZCmSu4WcvVwWIBzQHOPudg6PNIl+DOymj1n5b/W/x6/lRCfmaI/hh5CW4eaHWIgvXgrLaZ5y7dXKUA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/example/src/components.d.ts
+++ b/example/src/components.d.ts
@@ -20,6 +20,7 @@ export namespace Components {
         "last": string;
         /**
           * The middle name, defaults to "Unknown"
+          * @default "Unknown"
          */
         "middle": string;
         /**
@@ -84,6 +85,7 @@ declare namespace LocalJSX {
         "last"?: string;
         /**
           * The middle name, defaults to "Unknown"
+          * @default "Unknown"
          */
         "middle"?: string;
         /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,9 +1659,9 @@
       ]
     },
     "node_modules/@stencil/core": {
-      "version": "4.31.0",
-      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.31.0.tgz",
-      "integrity": "sha512-Ei9MFJ6LPD9BMFs+klkHylbVOOYhG10Jv4bvoFf3GMH15kA41rSYkEdr4DiX84ZdErQE2qtFV/2SUyWoXh0AhA==",
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.32.0.tgz",
+      "integrity": "sha512-2sT6UqEzZCmSu4WcvVwWIBzQHOPudg6PNIl+DOymj1n5b/W/x6/lRCfmaI/hh5CW4eaHWIgvXgrLaZ5y7dXKUA==",
       "dev": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
Replaces https://github.com/stencil-community/stencil-web-types/pull/223

