### PR TITLE
chore(repo): extend release age for renovate

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,17 +16,14 @@
    * The minimum age (in days) for updates that have a release timestamp header to be PR'ed.
    * This will not batch releases together - if package A gets a release on Monday, Tuesday and Wednesday and has a
    * `minimumReleaseAge: 3` and runs every day, then a PR will be created on:
-   * - Thursday (for Monday's release)
-   * - Friday (for Tuesday's release)
-   * - Saturday (for Wednesday's release)
+   * - Next Monday (for Monday's release)
+   * - Next Tuesday (for Tuesday's release)
+   * - Next Wednesday (for Wednesday's release)
    *
-   * This setting is to prevent a compromised package from being merged into Stencil in the first three days of its
+   * This setting is to prevent a compromised package from being merged into the project in the first seven days of its
    * release date
-   *
-   * A value of 3 days was chosen as npm packages younger than 72 hours old can be unpublished. This prevents merging
-   * support for a package that could be removed from the registry.
    */
-  minimumReleaseAge: '3 days',
+  minimumReleaseAge: '7 days',
   /**
    * Note: Renovate will evaluate all packageRules and not stop once it gets a first match.
    */
@@ -44,21 +41,13 @@
       groupName: 'Release It',
       matchPackageNames: ['release-it', '@release-it**/*'],
     },
-    {
-      // auto-merge anything that's not a major version bump
-      matchUpdateTypes: ['minor', 'patch', 'pin', 'digest'],
-      automerge: true,
-      automergeStrategy: 'rebase',
-    },
   ],
   // Rebase the branch to avoid a 'stalled' dependency update due to it falling behind
   rebaseWhen: 'behind-base-branch',
   /**
    * Run every Monday and Thursday between midnight at 11 AM (in UTC)
    *
-   * Monday and Thursday were chosen to:
-   * - Keep the `minimumReleaseAge` value in mind (three days)
-   * - Prevent spikes/bursts of PRs from Renovate on a single day of the week
+   * Monday and Thursday were chosen to prevent spikes/bursts of PRs from Renovate on a single day of the week
    *
    * We use cron syntax here as it's more deterministic/easier to provide a value that we know that Renovate will
    * accept, compared to the natural language syntax which is (subjectively) trickier to test without merging first.


### PR DESCRIPTION
extend the minimum release age for renovate to seven days instead of three. the npm ecosystem has had multiple CVEs lately with various npm packages. while this does not eliminate the potential for installing a compromised pacakge, it does have the opportunity to reduce its chances.

automerging has been removed from the project for additional package scrutiny.

.npmrc is updated/added with the same value, as an additional safeguard for local development.