### PR TITLE
chore(renovate): fix release-it glob

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -39,7 +39,7 @@
     },
     {
       groupName: 'Release It',
-      matchPackageNames: ['release-it', '@release-it**/*'],
+      matchPackageNames: ['release-it', '@release-it/*'],
     },
   ],
   // Rebase the branch to avoid a 'stalled' dependency update due to it falling behind


### PR DESCRIPTION
`@release-it/conventional-changelog` wasn't being properly picked up by this glob previously