### PR TITLE
chore(repo): use client id for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
create-github-app-token has deprecated app-id as of v3.1.0 - at the moment, publishes are failing with:

```console
Failed to create token for "stencil-web-types" (attempt 1): Invalid keyData
DOMException [DataError]: Invalid keyData
```

let's use the client id to steer us to the solution