### PR TITLE
chore(repo): update renovate group name for node

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,7 +29,7 @@
    */
   packageRules: [
     {
-      groupName: 'Node',
+      groupName: 'Node + Types',
       matchPackageNames: ['@types/node', 'node'],
       allowedVersions: '<25.0.0',
     },


### PR DESCRIPTION
Include "+ Types" in the Node group name, to clarify this is a group that can contain either/or updates rather than just updating Node