### PR TITLE
chore(renovate): only update renovate once a week

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -40,6 +40,13 @@
       groupName: 'Release It',
       matchPackageNames: ['release-it', '@release-it/*'],
     },
+    {
+      matchPackageNames: ['renovate'],
+      groupName: 'Renovate',
+      // these packages can be released multiple times a week, let's look at them every week
+      // Note: Timezone for the schedule is specified as UTC
+      schedule: ['before 11am on monday'],
+    },
   ],
   // Rebase the branch to avoid a 'stalled' dependency update due to it falling behind
   rebaseWhen: 'behind-base-branch',


### PR DESCRIPTION
This change cuts down on needless PRs, as this package gets released quite often. It's not enough to end the "let's make it an explicit dependency" experiment yet, but doesn't help.